### PR TITLE
Chromedriver url & fix separate_json arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install -r requirements.txt
 
 4. Install the [Google Chrome](https://chrome.google.com) browser, if not already installed
 
-5. Download the [Chrome WebDriver](https://sites.google.com/a/chromium.org/chromedriver/) and save it on the `cookidump` folder
+5. Download the [Chrome WebDriver](https://sites.google.com/chromium.org/driver/) and save it on the `cookidump` folder
 
 6. You are ready to dump your recipes
 
@@ -49,7 +49,7 @@ python cookidump.py [--separate-json] <webdriverfile> <outputdir>
 ```
 
 where:
-* `webdriverfile` identifies the path to the downloaded [Chrome WebDriver](https://sites.google.com/a/chromium.org/chromedriver/) (for instance, `chromedriver.exe` for Windows hosts, `./chromedriver` for Linux and macOS hosts)
+* `webdriverfile` identifies the path to the downloaded [Chrome WebDriver](https://sites.google.com/chromium.org/driver/) (for instance, `chromedriver.exe` for Windows hosts, `./chromedriver` for Linux and macOS hosts)
 * `outputdir` identifies the path of the output directory (will be created, if not already existent)
 * `--separate-json` allows to generate a separate JSON file for each recipe, instead of one aggregate file including all recipes
 

--- a/cookidump.py
+++ b/cookidump.py
@@ -234,4 +234,4 @@ if  __name__ =='__main__':
 	parser.add_argument('outputdir', type=str, help='the output directory')
 	parser.add_argument('-s', '--separate-json', action='store_true', help='Create a separate JSON file for each recipe; otherwise, a single data file will be generated')
 	args = parser.parse_args()
-	run(args.webdriverfile, args.outputdir, parser.separate_json)
+	run(args.webdriverfile, args.outputdir, args.separate_json)


### PR DESCRIPTION
Executing script resulted in an error due to using the parser object instead of the args object:
```
Traceback (most recent call last):
  File "cookidump.py", line 237, in <module>
    run(args.webdriverfile, args.outputdir, parser.separate_json)
AttributeError: 'ArgumentParser' object has no attribute 'separate_json'
```

This is fixed in the first commit.

The url to the chromedriver is getting deprecated soon. In the second commit the url is replaced with the new one.