### PR TITLE
Fix scrolling issue when loading more recipes

### DIFF
--- a/cookidump.py
+++ b/cookidump.py
@@ -127,7 +127,7 @@ def run(webdriverfile, outputdir, separate_json):
         time.sleep(SCROLL_TO)
         # clicking on the "load more recipes" button
         try:
-            brw.find_element(By.ID, 'load-more-page').click()
+            brw.find_element(By.XPATH, "//button[@data-cy='load-more-button']").click()
             time.sleep(PAGELOAD_TO)
         except: pass
         print('Scrolling [{}/{}]'.format(currentElements, elementsToBeFound))


### PR DESCRIPTION
The button to load more recipes no longer has the `id` `load-more-page`, but has the `data-cy` `load-more-button`. Button search modified.

Referenced issue: #31